### PR TITLE
feat: update golang-github-containerd-go-cni to 1.1.9

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,5 @@
 linters:
   enable:
-    - structcheck
-    - varcheck
     - staticcheck
     - unconvert
     - gofmt

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,21 @@
+golang-github-containerd-go-cni (1.1.9-2) unstable; urgency=medium
+
+  * Team upload
+  * Upload changes from experimental to unstable
+  * d/control:
+    - Update Standards-Version to 4.7.0 (no changes needed)
+    - Sync Depends with Build-Depends
+
+ -- Mathias Gibbens <gibmat@debian.org>  Thu, 25 Jul 2024 11:44:35 +0000
+
+golang-github-containerd-go-cni (1.1.9-1) experimental; urgency=medium
+
+  * Team upload
+  * New upstream version 1.1.9
+  * bump standards version, no changes needed
+
+ -- Reinhard Tartler <siretart@tauware.de>  Sat, 15 Jun 2024 07:13:31 -0400
+
 golang-github-containerd-go-cni (1.1.7-2) unstable; urgency=medium
 
   [ Shengjing Zhu ]

--- a/debian/control
+++ b/debian/control
@@ -13,7 +13,7 @@ Build-Depends-Indep:
  golang-any,
  golang-github-appc-cni-dev (>= 1.0.1~),
  golang-github-stretchr-testify-dev,
-Standards-Version: 4.6.1
+Standards-Version: 4.7.0
 Homepage: https://github.com/containerd/go-cni
 Vcs-Browser: https://salsa.debian.org/go-team/packages/golang-github-containerd-go-cni
 Vcs-Git: https://salsa.debian.org/go-team/packages/golang-github-containerd-go-cni.git
@@ -25,6 +25,7 @@ Architecture: all
 Multi-Arch: foreign
 Depends:
  golang-github-appc-cni-dev (>= 1.0.1~),
+ golang-github-stretchr-testify-dev,
  ${misc:Depends},
 Description: generic CNI library to provide APIs for CNI plugin interactions
  The library provides APIs to:

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module github.com/containerd/go-cni
 
-go 1.17
+go 1.19
 
 require (
-	github.com/containernetworking/cni v1.1.1
+	github.com/containernetworking/cni v1.1.2
 	github.com/stretchr/testify v1.8.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
-github.com/containernetworking/cni v1.1.1 h1:ky20T7c0MvKvbMOwS/FrlbNwjEoqJEUUYfsL4b0mc4k=
-github.com/containernetworking/cni v1.1.1/go.mod h1:sDpYKmGVENF3s6uvMvGgldDWeG8dMxakj/u+i9ht9vw=
+github.com/containernetworking/cni v1.1.2 h1:wtRGZVv7olUHMOqouPpn3cXJWpJgM6+EUl31EQbXALQ=
+github.com/containernetworking/cni v1.1.2/go.mod h1:sDpYKmGVENF3s6uvMvGgldDWeG8dMxakj/u+i9ht9vw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/integration/cni_setup_teardown_linux_test.go
+++ b/integration/cni_setup_teardown_linux_test.go
@@ -35,7 +35,6 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"runtime"
@@ -146,7 +145,7 @@ func TestBasicSetupAndRemove(t *testing.T) {
 	defer os.RemoveAll(tmpPluginConfDir)
 
 	assert.NoError(t,
-		ioutil.WriteFile(
+		os.WriteFile(
 			path.Join(tmpPluginConfDir, "10-gocni-test-net.conflist"),
 			[]byte(cniBridgePluginCfg),
 			0600,
@@ -231,7 +230,7 @@ func TestBasicSetupAndRemovePluginWithoutVersion(t *testing.T) {
 	defer os.RemoveAll(tmpPluginConfDir)
 
 	assert.NoError(t,
-		ioutil.WriteFile(
+		os.WriteFile(
 			path.Join(tmpPluginConfDir, "10-gocni-test-net.conflist"),
 			[]byte(cniBridgePluginCfgWithoutVersion),
 			0600,

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -10,7 +10,7 @@ require (
 
 require (
 	github.com/Microsoft/go-winio v0.5.1 // indirect
-	github.com/containernetworking/cni v1.1.1 // indirect
+	github.com/containernetworking/cni v1.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/sirupsen/logrus v1.7.0 // indirect

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -16,8 +16,8 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/containerd/continuity v0.2.2 h1:QSqfxcn8c+12slxwu00AtzXrsami0MJb/MQs9lOLHLA=
 github.com/containerd/continuity v0.2.2/go.mod h1:pWygW9u7LtS1o4N/Tn0FoCFDIXZ7rxcMX7HX1Dmibvk=
-github.com/containernetworking/cni v1.1.1 h1:ky20T7c0MvKvbMOwS/FrlbNwjEoqJEUUYfsL4b0mc4k=
-github.com/containernetworking/cni v1.1.1/go.mod h1:sDpYKmGVENF3s6uvMvGgldDWeG8dMxakj/u+i9ht9vw=
+github.com/containernetworking/cni v1.1.2 h1:wtRGZVv7olUHMOqouPpn3cXJWpJgM6+EUl31EQbXALQ=
+github.com/containernetworking/cni v1.1.2/go.mod h1:sDpYKmGVENF3s6uvMvGgldDWeG8dMxakj/u+i9ht9vw=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=

--- a/namespace_opts.go
+++ b/namespace_opts.go
@@ -50,6 +50,14 @@ func WithCapabilityDNS(dns DNS) NamespaceOpts {
 	}
 }
 
+// WithCapabilityCgroupPath passes in the cgroup path capability.
+func WithCapabilityCgroupPath(cgroupPath string) NamespaceOpts {
+	return func(c *Namespace) error {
+		c.capabilityArgs["cgroupPath"] = cgroupPath
+		return nil
+	}
+}
+
 // WithCapability support well-known capabilities
 // https://www.cni.dev/docs/conventions/#well-known-capabilities
 func WithCapability(name string, capability interface{}) NamespaceOpts {

--- a/result.go
+++ b/result.go
@@ -32,13 +32,18 @@ type IPConfig struct {
 // Result contains the network information returned by CNI.Setup
 //
 // a) Interfaces list. Depending on the plugin, this can include the sandbox
-//    (eg, container or hypervisor) interface name and/or the host interface
-//    name, the hardware addresses of each interface, and details about the
-//    sandbox (if any) the interface is in.
+//
+//	(eg, container or hypervisor) interface name and/or the host interface
+//	name, the hardware addresses of each interface, and details about the
+//	sandbox (if any) the interface is in.
+//
 // b) IP configuration assigned to each  interface. The IPv4 and/or IPv6 addresses,
-//    gateways, and routes assigned to sandbox and/or host interfaces.
+//
+//	gateways, and routes assigned to sandbox and/or host interfaces.
+//
 // c) DNS information. Dictionary that includes DNS information for nameservers,
-//     domain, search domains and options.
+//
+//	domain, search domains and options.
 type Result struct {
 	Interfaces map[string]*Config
 	DNS        []types.DNS

--- a/testutils.go
+++ b/testutils.go
@@ -18,14 +18,13 @@ package cni
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
 )
 
 func makeTmpDir(prefix string) (string, error) {
-	tmpDir, err := ioutil.TempDir(os.TempDir(), prefix)
+	tmpDir, err := os.MkdirTemp("", prefix)
 	if err != nil {
 		return "", err
 	}

--- a/types.go
+++ b/types.go
@@ -17,12 +17,9 @@
 package cni
 
 const (
-	CNIPluginName        = "cni"
-	DefaultNetDir        = "/etc/cni/net.d"
-	DefaultCNIDir        = "/opt/cni/bin"
-	DefaultMaxConfNum    = 1
-	VendorCNIDirTemplate = "%s/opt/%s/bin"
-	DefaultPrefix        = "eth"
+	CNIPluginName     = "cni"
+	DefaultMaxConfNum = 1
+	DefaultPrefix     = "eth"
 )
 
 type config struct {

--- a/types_others.go
+++ b/types_others.go
@@ -1,0 +1,25 @@
+//go:build !windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cni
+
+const (
+	DefaultNetDir        = "/etc/cni/net.d"
+	DefaultCNIDir        = "/opt/cni/bin"
+	VendorCNIDirTemplate = "%s/opt/%s/bin"
+)

--- a/types_windows.go
+++ b/types_windows.go
@@ -1,0 +1,24 @@
+//go:build windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cni
+
+const (
+	DefaultNetDir = "C:\\Program Files\\containerd\\cni\\conf"
+	DefaultCNIDir = "C:\\Program Files\\containerd\\cni\\bin"
+)


### PR DESCRIPTION
generic CNI library to provide APIs for CNI plugin interactions

Issue: https://github.com/deepin-community/sig-deepin-sysdev-team/issues/552
Log: update repo
